### PR TITLE
fix: revert ignore empty path and set serial to None

### DIFF
--- a/src/device.rs
+++ b/src/device.rs
@@ -91,6 +91,11 @@ impl PhysicalDevice {
     }
 
     fn try_with_serial_number_id(&mut self) {
+        if self.device_path.trim().is_empty() {
+            self.serial_number_id = None;
+            return;
+        }
+
         let wmi_con = wmi_con();
         let query = format!(
             "SELECT * FROM WmiMonitorID WHERE InstanceName LIKE '{}%'",
@@ -148,6 +153,11 @@ impl Device {
     }
 
     fn try_with_serial_number_id(&mut self) {
+        if self.device_path.trim().is_empty() {
+            self.serial_number_id = None;
+            return;
+        }
+
         let wmi_con = wmi_con();
         let query = format!(
             "SELECT * FROM WmiMonitorID WHERE InstanceName LIKE '{}%'",
@@ -262,12 +272,8 @@ pub fn connected_displays_all() -> impl Iterator<Item = Result<Device, SysError>
                                 serial_number_id: None,
                             };
 
-                            if !device.device_path.trim().is_empty() {
-                                device.try_with_serial_number_id();
-                                Ok(device)
-                            } else {
-                                Err(SysError::DeviceInfoMissing)
-                            }
+                            device.try_with_serial_number_id();
+                            Ok(device)
                         })
                         .collect()
                 }),
@@ -335,12 +341,8 @@ pub fn connected_displays_physical() -> impl Iterator<Item = Result<PhysicalDevi
                             serial_number_id: None,
                         };
 
-                        if !device.device_path.trim().is_empty() {
-                            device.try_with_serial_number_id();
-                            Ok(device)
-                        } else {
-                            Err(SysError::DeviceInfoMissing)
-                        }
+                        device.try_with_serial_number_id();
+                        Ok(device)
                     },
                 )
                 .collect()


### PR DESCRIPTION
This commit reverts the previous commit that ignored devices with empty path. Apparently some devices might have an empty path and still need to be handled, like remote displays. Now to fix the panics when trying to get the `serial_number_id` on devices with empty paths we handle that on the `try_with_serial_number_id` function it self by immediately setting `serial_number_id` to `None` and exiting early when the `device_path` is empty.